### PR TITLE
Fix annotation persistence logic

### DIFF
--- a/internal/controller/annotation.go
+++ b/internal/controller/annotation.go
@@ -38,7 +38,7 @@ func hasSpecAnnotation(resource *metav1.ObjectMeta) bool {
 }
 
 func saveSpecInAnnotations(resource *metav1.ObjectMeta, spec any) error {
-	if !hasSpecAnnotation(resource) {
+	if resource.Annotations == nil {
 		resource.Annotations = make(map[string]string)
 	}
 	serializedSpec, err := serializeSpec(spec)
@@ -65,7 +65,7 @@ func getSpecInAnnotations(resource *metav1.ObjectMeta, spec any) (bool, error) {
 }
 
 func deleteSpecInAnnotations(resource *metav1.ObjectMeta) {
-	if !hasSpecAnnotation(resource) {
+	if resource.Annotations == nil {
 		return
 	}
 	delete(resource.Annotations, specAnnotation)


### PR DESCRIPTION
## Summary
- avoid resetting object annotations when saving spec
- check for nil annotations map before deletion

## Testing
- `make test` *(fails: downloading dependencies forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685d1f6c8f28832a9107e0b62219dd9e