### PR TITLE
Fix logger key typo

### DIFF
--- a/internal/controller/lbregistrar_controller.go
+++ b/internal/controller/lbregistrar_controller.go
@@ -79,7 +79,7 @@ func (r *LBRegistrarReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	logger := log.FromContext(ctx,
 		"lbId", registrar.Spec.LoadBalancerId,
-		"backeneset", registrar.Spec.BackendSetName)
+		"backendset", registrar.Spec.BackendSetName)
 	ctx = log.IntoContext(ctx, logger)
 
 	defer func() {


### PR DESCRIPTION
## Summary
- fix a typo in the LB registrar logger context key

## Testing
- `go fmt ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d22b29118832ab0606d12160d970c