### PR TITLE
Improve secret retrieval error handling

### DIFF
--- a/internal/controller/secrets.go
+++ b/internal/controller/secrets.go
@@ -24,6 +24,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +45,14 @@ func GetSecretValue(ctx context.Context, clnt client.Client, namespace string, s
 		return "", err
 	}
 
-	value := string(secret.Data[sel.Key])
+	valueBytes, ok := secret.Data[sel.Key]
+	if !ok {
+		err := fmt.Errorf("secret key %s not found", sel.Key)
+		logger.Error(err, "Failed to get secret key")
+		return "", err
+	}
+
+	value := string(valueBytes)
 	logger.V(2).Info("Got secret")
 
 	return value, nil

--- a/internal/controller/secrets_test.go
+++ b/internal/controller/secrets_test.go
@@ -1,0 +1,41 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetSecretValue(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"},
+		Data:       map[string][]byte{"key": []byte("value")},
+	}
+	c := fake.NewClientBuilder().WithObjects(secret).Build()
+	ctx := context.Background()
+
+	val, err := GetSecretValue(ctx, c, "ns", &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}, Key: "key"})
+	if err != nil {
+		t.Fatalf("GetSecretValue returned error: %v", err)
+	}
+	if val != "value" {
+		t.Errorf("expected value, got %s", val)
+	}
+}
+
+func TestGetSecretValueMissingKey(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "secret", Namespace: "ns"},
+		Data:       map[string][]byte{"other": []byte("value")},
+	}
+	c := fake.NewClientBuilder().WithObjects(secret).Build()
+	ctx := context.Background()
+
+	_, err := GetSecretValue(ctx, c, "ns", &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "secret"}, Key: "missing"})
+	if err == nil {
+		t.Fatalf("expected error when key missing")
+	}
+}


### PR DESCRIPTION
## Summary
- return error if secret key missing
- add unit tests for GetSecretValue

## Testing
- `make vet`
- `go test ./...` *(fails: fork/exec ../../bin/k8s/1.29.0-linux-amd64/etcd: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6862cce5ccd8832ab0412cb74e9250b2