### PR TITLE
Add tests for annotation utilities

### DIFF
--- a/internal/controller/annotation_test.go
+++ b/internal/controller/annotation_test.go
@@ -112,3 +112,34 @@ func TestHasSpecAnnotation(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteSpecInAnnotations(t *testing.T) {
+	meta := &metav1.ObjectMeta{Annotations: map[string]string{specAnnotation: "data"}}
+	deleteSpecInAnnotations(meta)
+	if _, ok := meta.Annotations[specAnnotation]; ok {
+		t.Errorf("annotation not deleted")
+	}
+
+	// Should not panic when annotations map is nil
+	meta = &metav1.ObjectMeta{}
+	deleteSpecInAnnotations(meta)
+}
+
+func TestSerializeDeserializeSpec(t *testing.T) {
+	original := testSpec{Foo: "hello", Num: 42}
+	data, err := serializeSpec(original)
+	if err != nil {
+		t.Fatalf("serializeSpec returned error: %v", err)
+	}
+	var decoded testSpec
+	if err := deserializeSpec(data, &decoded); err != nil {
+		t.Fatalf("deserializeSpec returned error: %v", err)
+	}
+	if decoded != original {
+		t.Errorf("decoded struct does not match original: %#v vs %#v", decoded, original)
+	}
+
+	if err := deserializeSpec("{invalid", &decoded); err == nil {
+		t.Errorf("expected error for invalid JSON")
+	}
+}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -59,6 +59,9 @@ var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
+	binDir := filepath.Join("..", "..", "bin", "k8s",
+		fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH))
+	absBinDir, _ := filepath.Abs(binDir)
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
@@ -68,8 +71,7 @@ var _ = BeforeSuite(func() {
 		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
-			fmt.Sprintf("1.29.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+		BinaryAssetsDirectory: absBinDir,
 	}
 
 	var err error


### PR DESCRIPTION
## Summary
- expand annotation tests for delete and serialization
- use absolute path for envtest assets

## Testing
- `make vet`
- `go test $(go list ./... | grep -v /e2e)` *(fails: unable to start control plane)*

------
https://chatgpt.com/codex/tasks/task_e_68642b5b06ac832a9c7529db77e64a64