### PR TITLE
Update AGENTS instructions to use make test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 
 ## Testing
 - Run `make vet` before every commit
-- Run `go test ./...` on every commit
+- Run `make test` on every commit
 
 ## Commit Message
 - Follow Conventional Commits


### PR DESCRIPTION
## Summary
- update AGENTS.md to instruct running `make test` instead of `go test`

## Testing
- `go fmt ./...`
- `make vet` *(passes)*
- `go test ./...` *(fails: kubectl not found)*
- `make test` *(fails: BeforeSuite failure)*

------
https://chatgpt.com/codex/tasks/task_e_68665e18cd74832a803f2024456b9924