### PR TITLE
Enable TLS verification for ServiceMonitor

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -19,7 +19,7 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        insecureSkipVerify: true
+        insecureSkipVerify: false
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
## Summary
- update Prometheus ServiceMonitor to verify TLS

## Testing
- `make vet`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687b9450d33c832ab2e45690dfa2c49e