### PR TITLE
fix: enable TLS verification for ServiceMonitor

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -19,7 +19,6 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        insecureSkipVerify: false
   selector:
     matchLabels:
       control-plane: controller-manager


### PR DESCRIPTION
## Summary
- remove explicit `insecureSkipVerify` to enable TLS verification

## Testing
- `make fmt`
- `make vet`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687ceaceb4cc832a985cc59ffee7c5c2