### PR TITLE
Remove leftover TODO comments

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,10 +36,6 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
       # affinity:
       #   nodeAffinity:
       #     requiredDuringSchedulingIgnoredDuringExecution:
@@ -58,7 +54,7 @@ spec:
       #               - linux
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
+        # For common cases that do not require escalating privileges
         # it is recommended to ensure that all your Pods/Containers are restrictive.
         # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
         # Please uncomment the following code if your project does NOT have to work on old Kubernetes
@@ -89,7 +85,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
+        # Configure the resources accordingly based on the project requirements.
         # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
         resources:
           limits:

--- a/internal/controller/lbregistrar_controller.go
+++ b/internal/controller/lbregistrar_controller.go
@@ -60,13 +60,8 @@ type LBRegistrarReconciler struct {
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the LBRegistrar object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
+// Reconcile is part of the main kubernetes reconciliation loop which ensures
+// the cluster state reflects the LBRegistrar specification.
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.17.0/pkg/reconcile
 func (r *LBRegistrarReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary
- drop outdated TODO section in `LBRegistrarReconciler`
- clean up manager manifest comments

## Testing
- `go vet ./...`
- `go test $(go list ./... | grep -v /e2e)`
- `golangci-lint` *(failed: command timed out)*
- `govulncheck ./...` *(failed: 503 Service Unavailable)*
- `gosec` *(failed: command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687e698b8718832aa95203c5038be6b3