### PR TITLE
test: ensure GetIPAddress returns first internal IP

### DIFF
--- a/internal/controller/models/models_test.go
+++ b/internal/controller/models/models_test.go
@@ -34,3 +34,45 @@ func TestGetIPAddressNoInternalIP(t *testing.T) {
 		t.Errorf("expected empty IP, got %s", ip)
 	}
 }
+
+func TestGetIPAddressReturnsFirstInternalIP(t *testing.T) {
+	cases := []struct {
+		name      string
+		addresses []corev1.NodeAddress
+		expected  string
+	}{
+		{
+			name: "internal_ip_first",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+				{Type: corev1.NodeExternalIP, Address: "1.1.1.1"},
+			},
+			expected: "10.0.0.1",
+		},
+		{
+			name: "internal_ip_after_external",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeExternalIP, Address: "1.1.1.1"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.2"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+			},
+			expected: "10.0.0.2",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			node := &corev1.Node{
+				Status: corev1.NodeStatus{
+					Addresses: tc.addresses,
+				},
+			}
+			ip := GetIPAddress(node)
+			if ip != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, ip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add unit test verifying GetIPAddress returns first InternalIP regardless of order

## Testing
- `make vet`
- `make lint` *(fails: context loading failed: context deadline exceeded)*
- `make test`
- `make vulcheck`
- `make seccheck`


------
https://chatgpt.com/codex/tasks/task_e_68c7dec21d5c832a80aff74882866391