### PR TITLE
test: add unassigned NodePort service test

### DIFF
--- a/internal/controller/getnodeport_service_unassigned_test.go
+++ b/internal/controller/getnodeport_service_unassigned_test.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "github.com/norseto/oci-lb-controller/api/v1alpha1"
+)
+
+func TestGetNodePortFromServiceUnassigned(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+		Spec: corev1.ServiceSpec{
+			Type:  corev1.ServiceTypeNodePort,
+			Ports: []corev1.ServicePort{{Port: 80, NodePort: 0}},
+		},
+	}
+	c := fake.NewClientBuilder().WithObjects(svc).Build()
+	ctx := context.Background()
+	spec := &api.ServiceSpec{Name: "svc", Namespace: "default", Port: intstr.FromInt(80)}
+	_, err := getNodePortFromService(ctx, c, spec)
+	if err == nil || !strings.Contains(err.Error(), "nodePort is not allocated") {
+		t.Fatalf("expected error indicating unallocated nodePort, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add test for service with unassigned NodePort

## Testing
- `make vet`
- `make test`
- `make lint` *(fails: context deadline exceeded)*
- `bin/golangci-lint-v1.64.8 run --timeout 5m -v`
- `make vulcheck`
- `make seccheck`

------
https://chatgpt.com/codex/tasks/task_e_68c7deb17acc832a84406541d5b77b91