### PR TITLE
feat: enable fake OCI clients and add tests

### DIFF
--- a/internal/controller/cloud/oci/loadbalancer/loadbalancer_test.go
+++ b/internal/controller/cloud/oci/loadbalancer/loadbalancer_test.go
@@ -1,0 +1,107 @@
+package loadbalancer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	ocilb "github.com/oracle/oci-go-sdk/v65/loadbalancer"
+	corev1 "k8s.io/api/core/v1"
+
+	api "github.com/norseto/oci-lb-controller/api/v1alpha1"
+)
+
+type fakeLBClient struct {
+	getResp   ocilb.GetBackendSetResponse
+	updateReq *ocilb.UpdateBackendSetRequest
+}
+
+func (f *fakeLBClient) GetBackendSet(ctx context.Context, req ocilb.GetBackendSetRequest) (ocilb.GetBackendSetResponse, error) {
+	return f.getResp, nil
+}
+
+func (f *fakeLBClient) UpdateBackendSet(ctx context.Context, req ocilb.UpdateBackendSetRequest) (ocilb.UpdateBackendSetResponse, error) {
+	f.updateReq = &req
+	return ocilb.UpdateBackendSetResponse{}, nil
+}
+
+func TestGetBackendSet(t *testing.T) {
+	orig := newLBClient
+	defer func() { newLBClient = orig }()
+	fake := &fakeLBClient{
+		getResp: ocilb.GetBackendSetResponse{
+			BackendSet: ocilb.BackendSet{
+				Backends: []ocilb.Backend{
+					{Name: common.String("b1"), IpAddress: common.String("1.1.1.1"), Port: common.Int(80), Weight: common.Int(1)},
+					{Name: common.String("b2"), IpAddress: common.String("2.2.2.2"), Port: common.Int(8080), Weight: common.Int(2)},
+				},
+			},
+		},
+	}
+	newLBClient = func(provider common.ConfigurationProvider) (LoadBalancerClient, error) { return fake, nil }
+	spec := api.LBRegistrarSpec{LoadBalancerId: "lb", BackendSetName: "bs"}
+	targets, err := GetBackendSet(context.Background(), nil, spec)
+	if err != nil {
+		t.Fatalf("GetBackendSet error: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets, got %d", len(targets))
+	}
+	if targets[0].Name != "b1" || targets[0].IpAddress != "1.1.1.1" || targets[0].Port != 80 || targets[0].Weight != 1 {
+		t.Fatalf("unexpected target: %#v", targets[0])
+	}
+}
+
+func TestRegisterBackends(t *testing.T) {
+	orig := newLBClient
+	defer func() { newLBClient = orig }()
+	hcPort := 1024
+	fake := &fakeLBClient{
+		getResp: ocilb.GetBackendSetResponse{
+			BackendSet: ocilb.BackendSet{
+				Policy:        common.String("ROUND_ROBIN"),
+				HealthChecker: &ocilb.HealthChecker{Protocol: common.String("HTTP"), Port: common.Int(hcPort)},
+			},
+		},
+	}
+	newLBClient = func(provider common.ConfigurationProvider) (LoadBalancerClient, error) { return fake, nil }
+	nodes := &corev1.NodeList{Items: []corev1.Node{
+		{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.1"}}}},
+		{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.2"}}}},
+	}}
+	spec := api.LBRegistrarSpec{LoadBalancerId: "lb", BackendSetName: "bs", NodePort: 30000, Port: 80, Weight: 5}
+	if err := RegisterBackends(context.Background(), nil, spec, nodes); err != nil {
+		t.Fatalf("RegisterBackends error: %v", err)
+	}
+	req := fake.updateReq
+	if req == nil {
+		t.Fatalf("UpdateBackendSet not called")
+	}
+	if *req.LoadBalancerId != spec.LoadBalancerId {
+		t.Errorf("LoadBalancerId = %s, want %s", *req.LoadBalancerId, spec.LoadBalancerId)
+	}
+	if *req.BackendSetName != spec.BackendSetName {
+		t.Errorf("BackendSetName = %s, want %s", *req.BackendSetName, spec.BackendSetName)
+	}
+	if len(req.UpdateBackendSetDetails.Backends) != len(nodes.Items) {
+		t.Fatalf("backends len = %d, want %d", len(req.UpdateBackendSetDetails.Backends), len(nodes.Items))
+	}
+	for i, b := range req.UpdateBackendSetDetails.Backends {
+		expectedIP := nodes.Items[i].Status.Addresses[0].Address
+		if *b.IpAddress != expectedIP {
+			t.Errorf("backend %d ip = %s, want %s", i, *b.IpAddress, expectedIP)
+		}
+		if *b.Port != spec.Port {
+			t.Errorf("backend %d port = %d, want %d", i, *b.Port, spec.Port)
+		}
+		if *b.Weight != spec.Weight {
+			t.Errorf("backend %d weight = %d, want %d", i, *b.Weight, spec.Weight)
+		}
+	}
+	if req.UpdateBackendSetDetails.Policy == nil || *req.UpdateBackendSetDetails.Policy != "ROUND_ROBIN" {
+		t.Errorf("policy = %v, want ROUND_ROBIN", req.UpdateBackendSetDetails.Policy)
+	}
+	if req.UpdateBackendSetDetails.HealthChecker == nil || *req.UpdateBackendSetDetails.HealthChecker.Protocol != "HTTP" || *req.UpdateBackendSetDetails.HealthChecker.Port != hcPort {
+		t.Errorf("unexpected health checker %+v", req.UpdateBackendSetDetails.HealthChecker)
+	}
+}

--- a/internal/controller/cloud/oci/networkloadbalancer/networkloadbalancer_workrequest_test.go
+++ b/internal/controller/cloud/oci/networkloadbalancer/networkloadbalancer_workrequest_test.go
@@ -1,0 +1,113 @@
+package networkloadbalancer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+	ocilb "github.com/oracle/oci-go-sdk/v65/networkloadbalancer"
+)
+
+type fakeNLBClient struct {
+	statuses []ocilb.OperationStatusEnum
+	idx      int
+}
+
+func (f *fakeNLBClient) GetBackendSet(ctx context.Context, req ocilb.GetBackendSetRequest) (ocilb.GetBackendSetResponse, error) {
+	return ocilb.GetBackendSetResponse{}, nil
+}
+
+func (f *fakeNLBClient) UpdateBackendSet(ctx context.Context, req ocilb.UpdateBackendSetRequest) (ocilb.UpdateBackendSetResponse, error) {
+	return ocilb.UpdateBackendSetResponse{}, nil
+}
+
+func (f *fakeNLBClient) GetWorkRequest(ctx context.Context, req ocilb.GetWorkRequestRequest) (ocilb.GetWorkRequestResponse, error) {
+	status := f.statuses[f.idx]
+	if f.idx < len(f.statuses)-1 {
+		f.idx++
+	}
+	return ocilb.GetWorkRequestResponse{WorkRequest: ocilb.WorkRequest{Status: status}}, nil
+}
+
+func TestWaitForWorkRequestCompletion(t *testing.T) {
+	orig := newNLBClient
+	defer func() { newNLBClient = orig }()
+	cases := []struct {
+		name     string
+		statuses []ocilb.OperationStatusEnum
+		makeCtx  func() (context.Context, context.CancelFunc)
+		wantErr  bool
+	}{
+		{
+			name:     "Succeeded",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusSucceeded},
+			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+		},
+		{
+			name:     "Failed",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusFailed},
+			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+			wantErr:  true,
+		},
+		{
+			name:     "Canceled",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusCanceled},
+			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+			wantErr:  true,
+		},
+		{
+			name:     "InProgress",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusInProgress, ocilb.OperationStatusSucceeded},
+			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+		},
+		{
+			name:     "Accepted",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusAccepted, ocilb.OperationStatusSucceeded},
+			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+		},
+		{
+			name:     "Unknown",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusEnum("UNKNOWN"), ocilb.OperationStatusSucceeded},
+			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+		},
+		{
+			name:     "ContextCanceled",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusInProgress},
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				time.AfterFunc(100*time.Millisecond, cancel)
+				return ctx, cancel
+			},
+			wantErr: true,
+		},
+		{
+			name:     "ContextTimeout",
+			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusInProgress},
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 100*time.Millisecond)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeNLBClient{statuses: tt.statuses}
+			newNLBClient = func(provider common.ConfigurationProvider) (NetworkLoadBalancerClient, error) { return fake, nil }
+			ctx, cancel := tt.makeCtx()
+			defer cancel()
+			client, _ := newNLBClient(nil)
+			err := waitForWorkRequestCompletion(ctx, client, common.String("wr"))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- allow load balancer and network load balancer clients to be replaced for tests
- verify load balancer backend conversions and update request fields
- exercise network load balancer work request polling across statuses

## Testing
- `make vet`
- `make lint` *(fails: context deadline exceeded)*
- `make test`
- `make vulcheck`
- `make seccheck`


------
https://chatgpt.com/codex/tasks/task_e_68c800278b00832aa42e5acd8ebd43ec