### PR TITLE
chore: bump Go toolchain to 1.24.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.6 AS builder
+FROM golang:1.24.7 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GITVERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/norseto/oci-lb-controller
 
-go 1.24.6
+go 1.24.7
 
 require (
 	github.com/onsi/ginkgo/v2 v2.22.0


### PR DESCRIPTION
## Summary
- update the module go directive to 1.24.7 and refresh dependencies
- switch the builder stage to golang:1.24.7 to match the new toolchain

## Testing
- go mod tidy
- make fmt
- make vet *(pass)*
- make lint *(fails: context deadline exceeded)*
- make test
- make vulcheck
- make seccheck
- go test ./... -coverprofile=coverage.out
- go tool cover -func coverage.out

------
https://chatgpt.com/codex/tasks/task_e_68d7cd0d7e34832aac8e774723d24063