### PR TITLE
chore: bump devcontainer go toolchain to 1.24.7

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.6"
+      "version": "1.24.7"
     },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
       "version": "latest",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ This operator provides the following features:
 - **Multi-service support**: Single `LBRegistrar` resource can manage multiple services and backend sets, eliminating conflicts.
 - **Multi-Load Balancer support**: Supports multiple `LBRegistrar` resources to register nodes with different Load Balancers.
 
+## Development Environment
+
+- The Dev Container configuration provides the Go 1.24.7 toolchain via `ghcr.io/devcontainers/features/go:1`.
+
 ## Usage
 
 1. **Setup OCI LoadBalancer**:


### PR DESCRIPTION
## Summary
- update the devcontainer Go feature to install version 1.24.7
- document the devcontainer Go toolchain version in the README for developers

## Testing
- make fmt
- make vet *(fails: go vet hung in this environment and was interrupted)*
- make test *(fails: go vet sub-step hung in this environment and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d75be60c832ab583c8603f27566d