### PR TITLE
Upgrade golangci-lint v2 and adjust NLB backend handling

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-config-version: 2
+version: 2
 run:
   deadline: 5m
   allow-parallel-runners: true
@@ -24,9 +24,6 @@ linters:
     - errcheck
     - goconst
     - gocyclo
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - lll
@@ -34,7 +31,11 @@ linters:
     - nakedret
     - prealloc
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - Run `make lint` on every commit
 - Run `make vulcheck` on every commit
 - Run `make seccheck` on every commit
+- Coverrage: 80%
 - Do not create PR if test fails
 
 ### Test Coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ The project uses Ginkgo/Gomega for testing:
 - Unit tests in `*_test.go` files
 - E2E tests in `test/e2e/`
 - Test utilities in `test/utils/`
+- Coverrage: 80%
 
 Run specific tests with:
 - `go test ./internal/controller/` - Run controller tests only

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ GOSEC       = $(LOCALBIN)/gosec-$(GOSEC_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.0
 ENVTEST_VERSION ?= latest
-GOLANGCI_LINT_VERSION ?= v1.64.8
+GOLANGCI_LINT_VERSION ?= v2.8.0
 GOVULNCHECK_VERSION ?= latest
 GOSEC_VERSION       ?= latest
 
@@ -219,7 +219,7 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
 
 .PHONY: govulncheck
 govulncheck: $(GOVULNCHECK) ## Download govulncheck locally if necessary.

--- a/internal/controller/cloud/oci/loadbalancer/loadbalancer_test.go
+++ b/internal/controller/cloud/oci/loadbalancer/loadbalancer_test.go
@@ -114,10 +114,10 @@ func TestRegisterBackends(t *testing.T) {
 	if *req.BackendSetName != spec.BackendSetName {
 		t.Errorf("BackendSetName = %s, want %s", *req.BackendSetName, spec.BackendSetName)
 	}
-	if len(req.UpdateBackendSetDetails.Backends) != len(nodes.Items) {
-		t.Fatalf("backends len = %d, want %d", len(req.UpdateBackendSetDetails.Backends), len(nodes.Items))
+	if len(req.Backends) != len(nodes.Items) {
+		t.Fatalf("backends len = %d, want %d", len(req.Backends), len(nodes.Items))
 	}
-	for i, b := range req.UpdateBackendSetDetails.Backends {
+	for i, b := range req.Backends {
 		expectedIP := nodes.Items[i].Status.Addresses[0].Address
 		if *b.IpAddress != expectedIP {
 			t.Errorf("backend %d ip = %s, want %s", i, *b.IpAddress, expectedIP)
@@ -129,13 +129,13 @@ func TestRegisterBackends(t *testing.T) {
 			t.Errorf("backend %d weight = %d, want %d", i, *b.Weight, spec.Weight)
 		}
 	}
-	if req.UpdateBackendSetDetails.Policy == nil || *req.UpdateBackendSetDetails.Policy != "ROUND_ROBIN" {
-		t.Errorf("policy = %v, want ROUND_ROBIN", req.UpdateBackendSetDetails.Policy)
+	if req.Policy == nil || *req.Policy != "ROUND_ROBIN" {
+		t.Errorf("policy = %v, want ROUND_ROBIN", req.Policy)
 	}
-	if req.UpdateBackendSetDetails.HealthChecker == nil ||
-		*req.UpdateBackendSetDetails.HealthChecker.Protocol != "HTTP" ||
-		*req.UpdateBackendSetDetails.HealthChecker.Port != hcPort {
-		t.Errorf("unexpected health checker %+v", req.UpdateBackendSetDetails.HealthChecker)
+	if req.HealthChecker == nil ||
+		*req.HealthChecker.Protocol != "HTTP" ||
+		*req.HealthChecker.Port != hcPort {
+		t.Errorf("unexpected health checker %+v", req.HealthChecker)
 	}
 }
 

--- a/internal/controller/cloud/oci/networkloadbalancer/networkloadbalancer_workrequest_test.go
+++ b/internal/controller/cloud/oci/networkloadbalancer/networkloadbalancer_workrequest_test.go
@@ -18,15 +18,24 @@ type fakeNLBClient struct {
 	idx      int
 }
 
-func (f *fakeNLBClient) GetBackendSet(ctx context.Context, req ocilb.GetBackendSetRequest) (ocilb.GetBackendSetResponse, error) {
+func (f *fakeNLBClient) GetBackendSet(
+	ctx context.Context,
+	req ocilb.GetBackendSetRequest,
+) (ocilb.GetBackendSetResponse, error) {
 	return ocilb.GetBackendSetResponse{}, nil
 }
 
-func (f *fakeNLBClient) UpdateBackendSet(ctx context.Context, req ocilb.UpdateBackendSetRequest) (ocilb.UpdateBackendSetResponse, error) {
+func (f *fakeNLBClient) UpdateBackendSet(
+	ctx context.Context,
+	req ocilb.UpdateBackendSetRequest,
+) (ocilb.UpdateBackendSetResponse, error) {
 	return ocilb.UpdateBackendSetResponse{}, nil
 }
 
-func (f *fakeNLBClient) GetWorkRequest(ctx context.Context, req ocilb.GetWorkRequestRequest) (ocilb.GetWorkRequestResponse, error) {
+func (f *fakeNLBClient) GetWorkRequest(
+	ctx context.Context,
+	req ocilb.GetWorkRequestRequest,
+) (ocilb.GetWorkRequestResponse, error) {
 	status := f.statuses[f.idx]
 	if f.idx < len(f.statuses)-1 {
 		f.idx++
@@ -58,34 +67,55 @@ func TestWaitForWorkRequestCompletion(t *testing.T) {
 		{
 			name:     "Succeeded",
 			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusSucceeded},
-			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
 		},
 		{
 			name:     "Failed",
 			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusFailed},
-			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
-			wantErr:  true,
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			wantErr: true,
 		},
 		{
 			name:     "Canceled",
 			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusCanceled},
-			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
-			wantErr:  true,
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
+			wantErr: true,
 		},
 		{
-			name:     "InProgress",
-			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusInProgress, ocilb.OperationStatusSucceeded},
-			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+			name: "InProgress",
+			statuses: []ocilb.OperationStatusEnum{
+				ocilb.OperationStatusInProgress,
+				ocilb.OperationStatusSucceeded,
+			},
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
 		},
 		{
-			name:     "Accepted",
-			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusAccepted, ocilb.OperationStatusSucceeded},
-			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+			name: "Accepted",
+			statuses: []ocilb.OperationStatusEnum{
+				ocilb.OperationStatusAccepted,
+				ocilb.OperationStatusSucceeded,
+			},
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
 		},
 		{
-			name:     "Unknown",
-			statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusEnum("UNKNOWN"), ocilb.OperationStatusSucceeded},
-			makeCtx:  func() (context.Context, context.CancelFunc) { return context.Background(), func() {} },
+			name: "Unknown",
+			statuses: []ocilb.OperationStatusEnum{
+				ocilb.OperationStatusEnum("UNKNOWN"),
+				ocilb.OperationStatusSucceeded,
+			},
+			makeCtx: func() (context.Context, context.CancelFunc) {
+				return context.Background(), func() {}
+			},
 		},
 		{
 			name:     "ContextCanceled",
@@ -110,7 +140,9 @@ func TestWaitForWorkRequestCompletion(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			fake := &fakeNLBClient{statuses: tt.statuses}
-			newNLBClient = func(provider common.ConfigurationProvider) (NetworkLoadBalancerClient, error) { return fake, nil }
+			newNLBClient = func(provider common.ConfigurationProvider) (NetworkLoadBalancerClient, error) {
+				return fake, nil
+			}
 			ctx, cancel := tt.makeCtx()
 			defer cancel()
 			client, _ := newNLBClient(nil)
@@ -135,14 +167,20 @@ type fullFakeClient struct {
 	fakeNLBClient
 }
 
-func (f *fullFakeClient) GetBackendSet(ctx context.Context, req ocilb.GetBackendSetRequest) (ocilb.GetBackendSetResponse, error) {
+func (f *fullFakeClient) GetBackendSet(
+	ctx context.Context,
+	req ocilb.GetBackendSetRequest,
+) (ocilb.GetBackendSetResponse, error) {
 	if f.getErr != nil {
 		return ocilb.GetBackendSetResponse{}, f.getErr
 	}
 	return f.getResp, nil
 }
 
-func (f *fullFakeClient) UpdateBackendSet(ctx context.Context, req ocilb.UpdateBackendSetRequest) (ocilb.UpdateBackendSetResponse, error) {
+func (f *fullFakeClient) UpdateBackendSet(
+	ctx context.Context,
+	req ocilb.UpdateBackendSetRequest,
+) (ocilb.UpdateBackendSetResponse, error) {
 	if f.updateErr != nil {
 		return ocilb.UpdateBackendSetResponse{}, f.updateErr
 	}
@@ -162,7 +200,10 @@ func TestGetBackendSetAndRegister(t *testing.T) {
 				Policy:        ocilb.NetworkLoadBalancingPolicyFiveTuple,
 				HealthChecker: &ocilb.HealthChecker{Protocol: ocilb.HealthCheckProtocolsTcp},
 				Backends: []ocilb.Backend{{
-					Name: common.String("b"), IpAddress: common.String("10.0.0.1"), Port: common.Int(80), Weight: common.Int(1),
+					Name:      common.String("b"),
+					IpAddress: common.String("10.0.0.1"),
+					Port:      common.Int(80),
+					Weight:    common.Int(1),
 				}},
 			}},
 			fakeNLBClient: fakeNLBClient{statuses: []ocilb.OperationStatusEnum{ocilb.OperationStatusSucceeded}},
@@ -173,13 +214,32 @@ func TestGetBackendSetAndRegister(t *testing.T) {
 		go func() { ch <- time.Time{} }()
 		return ch
 	}
-	targets, err := GetBackendSet(context.Background(), nil, api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1..x", BackendSetName: "bs"})
+	spec := api.LBRegistrarSpec{
+		LoadBalancerId: "ocid1.networkloadbalancer.oc1..x",
+		BackendSetName: "bs",
+	}
+	targets, err := GetBackendSet(context.Background(), nil, spec)
 	if err != nil || len(targets) != 1 {
 		t.Fatalf("unexpected targets %v err=%v", targets, err)
 	}
 
-	nodes := &corev1.NodeList{Items: []corev1.Node{{Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: "10.0.0.2"}}}}}}
-	if err := RegisterBackends(context.Background(), nil, api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1..x", BackendSetName: "bs", NodePort: 30000, Weight: 1}, nodes); err != nil {
+	nodes := &corev1.NodeList{
+		Items: []corev1.Node{{
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{{
+					Type:    corev1.NodeInternalIP,
+					Address: "10.0.0.2",
+				}},
+			},
+		}},
+	}
+	updateSpec := api.LBRegistrarSpec{
+		LoadBalancerId: "ocid1.networkloadbalancer.oc1..x",
+		BackendSetName: "bs",
+		NodePort:       30000,
+		Weight:         1,
+	}
+	if err := RegisterBackends(context.Background(), nil, updateSpec, nodes); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -190,7 +250,10 @@ type delegatingAPI struct {
 	workCalled   bool
 }
 
-func (d *delegatingAPI) GetBackendSet(ctx context.Context, req ocilb.GetBackendSetRequest) (ocilb.GetBackendSetResponse, error) {
+func (d *delegatingAPI) GetBackendSet(
+	ctx context.Context,
+	req ocilb.GetBackendSetRequest,
+) (ocilb.GetBackendSetResponse, error) {
 	d.getCalled = true
 	if req.NetworkLoadBalancerId == nil {
 		return ocilb.GetBackendSetResponse{}, errors.New("missing id")
@@ -198,12 +261,18 @@ func (d *delegatingAPI) GetBackendSet(ctx context.Context, req ocilb.GetBackendS
 	return ocilb.GetBackendSetResponse{}, nil
 }
 
-func (d *delegatingAPI) UpdateBackendSet(ctx context.Context, req ocilb.UpdateBackendSetRequest) (ocilb.UpdateBackendSetResponse, error) {
+func (d *delegatingAPI) UpdateBackendSet(
+	ctx context.Context,
+	req ocilb.UpdateBackendSetRequest,
+) (ocilb.UpdateBackendSetResponse, error) {
 	d.updateCalled = true
 	return ocilb.UpdateBackendSetResponse{}, nil
 }
 
-func (d *delegatingAPI) GetWorkRequest(ctx context.Context, req ocilb.GetWorkRequestRequest) (ocilb.GetWorkRequestResponse, error) {
+func (d *delegatingAPI) GetWorkRequest(
+	ctx context.Context,
+	req ocilb.GetWorkRequestRequest,
+) (ocilb.GetWorkRequestResponse, error) {
 	d.workCalled = true
 	return ocilb.GetWorkRequestResponse{}, nil
 }
@@ -212,7 +281,10 @@ func TestOCINLBClientDelegates(t *testing.T) {
 	api := &delegatingAPI{}
 	client := &ociNLBClient{api: api}
 
-	if _, err := client.GetBackendSet(context.Background(), ocilb.GetBackendSetRequest{NetworkLoadBalancerId: common.String("id")}); err != nil {
+	if _, err := client.GetBackendSet(
+		context.Background(),
+		ocilb.GetBackendSetRequest{NetworkLoadBalancerId: common.String("id")},
+	); err != nil {
 		t.Fatalf("GetBackendSet error: %v", err)
 	}
 	if _, err := client.UpdateBackendSet(context.Background(), ocilb.UpdateBackendSetRequest{}); err != nil {

--- a/internal/controller/cloud/oci/provider.go
+++ b/internal/controller/cloud/oci/provider.go
@@ -45,7 +45,11 @@ var (
 
 // NewConfigurationProvider is a function that creates a new instance of the ConfigurationProvider interface.
 // It takes in a context.Context object, a pointer to an api.ApiKeySpec object
-func NewConfigurationProvider(ctx context.Context, spec *api.ApiKeySpec, privateKey string) (common.ConfigurationProvider, error) {
+func NewConfigurationProvider(
+	ctx context.Context,
+	spec *api.ApiKeySpec,
+	privateKey string,
+) (common.ConfigurationProvider, error) {
 	_ = log.FromContext(ctx)
 
 	key := api.ApiKeySpec{}
@@ -53,7 +57,13 @@ func NewConfigurationProvider(ctx context.Context, spec *api.ApiKeySpec, private
 	spec.DeepCopyInto(&key)
 
 	provider := common.NewRawConfigurationProvider(
-		key.Tenancy, key.User, key.Region, key.Fingerprint, privateKey, &pass)
+		key.Tenancy,
+		key.User,
+		key.Region,
+		key.Fingerprint,
+		privateKey,
+		&pass,
+	)
 	return provider, nil
 }
 
@@ -61,15 +71,23 @@ func isNetworkLoadBalancer(spec api.LBRegistrarSpec) bool {
 	return strings.Contains(spec.LoadBalancerId, ".networkloadbalancer.")
 }
 
-func GetBackendSet(ctx context.Context, provider common.ConfigurationProvider, spec api.LBRegistrarSpec) ([]*models.LoadBalanceTarget, error) {
+func GetBackendSet(
+	ctx context.Context,
+	provider common.ConfigurationProvider,
+	spec api.LBRegistrarSpec,
+) ([]*models.LoadBalanceTarget, error) {
 	if isNetworkLoadBalancer(spec) {
 		return networkLoadBalancerGetBackendSet(ctx, provider, spec)
 	}
 	return loadBalancerGetBackendSet(ctx, provider, spec)
 }
 
-func RegisterBackends(ctx context.Context, provider common.ConfigurationProvider,
-	spec api.LBRegistrarSpec, targets *corev1.NodeList) error {
+func RegisterBackends(
+	ctx context.Context,
+	provider common.ConfigurationProvider,
+	spec api.LBRegistrarSpec,
+	targets *corev1.NodeList,
+) error {
 	if isNetworkLoadBalancer(spec) {
 		return networkRegisterBackends(ctx, provider, spec, targets)
 	}

--- a/internal/controller/cloud/oci/provider_test.go
+++ b/internal/controller/cloud/oci/provider_test.go
@@ -39,8 +39,16 @@ func TestIsNetworkLoadBalancer(t *testing.T) {
 		spec     api.LBRegistrarSpec
 		expected bool
 	}{
-		{"Network Load Balancer", api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1.phx.exampleuniqueID"}, true},
-		{"Load Balancer", api.LBRegistrarSpec{LoadBalancerId: "ocid1.loadbalancer.oc1.phx.exampleuniqueID"}, false},
+		{
+			"Network Load Balancer",
+			api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1.phx.exampleuniqueID"},
+			true,
+		},
+		{
+			"Load Balancer",
+			api.LBRegistrarSpec{LoadBalancerId: "ocid1.loadbalancer.oc1.phx.exampleuniqueID"},
+			false,
+		},
 		{"Empty Load Balancer", api.LBRegistrarSpec{LoadBalancerId: ""}, false},
 	}
 
@@ -63,27 +71,55 @@ func TestGetBackendSetDelegation(t *testing.T) {
 	}()
 
 	calledLB := false
-	loadBalancerGetBackendSet = func(context.Context, common.ConfigurationProvider, api.LBRegistrarSpec) ([]*models.LoadBalanceTarget, error) {
+	loadBalancerGetBackendSet = func(
+		context.Context,
+		common.ConfigurationProvider,
+		api.LBRegistrarSpec,
+	) ([]*models.LoadBalanceTarget, error) {
 		calledLB = true
 		return []*models.LoadBalanceTarget{{Name: "lb"}}, nil
 	}
 
 	calledNLB := false
-	networkLoadBalancerGetBackendSet = func(context.Context, common.ConfigurationProvider, api.LBRegistrarSpec) ([]*models.LoadBalanceTarget, error) {
+	networkLoadBalancerGetBackendSet = func(
+		context.Context,
+		common.ConfigurationProvider,
+		api.LBRegistrarSpec,
+	) ([]*models.LoadBalanceTarget, error) {
 		calledNLB = true
 		return []*models.LoadBalanceTarget{{Name: "nlb"}}, nil
 	}
 
-	targets, err := GetBackendSet(context.Background(), nil, api.LBRegistrarSpec{LoadBalancerId: "ocid1.loadbalancer"})
+	targets, err := GetBackendSet(
+		context.Background(),
+		nil,
+		api.LBRegistrarSpec{LoadBalancerId: "ocid1.loadbalancer"},
+	)
 	if err != nil || !calledLB || calledNLB || targets[0].Name != "lb" {
-		t.Fatalf("expected load balancer path: calledLB=%v calledNLB=%v targets=%v err=%v", calledLB, calledNLB, targets, err)
+		t.Fatalf(
+			"expected load balancer path: calledLB=%v calledNLB=%v targets=%v err=%v",
+			calledLB,
+			calledNLB,
+			targets,
+			err,
+		)
 	}
 
 	calledLB = false
 	calledNLB = false
-	targets, err = GetBackendSet(context.Background(), nil, api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1"})
+	targets, err = GetBackendSet(
+		context.Background(),
+		nil,
+		api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1"},
+	)
 	if err != nil || !calledNLB || calledLB || targets[0].Name != "nlb" {
-		t.Fatalf("expected network load balancer path: calledLB=%v calledNLB=%v targets=%v err=%v", calledLB, calledNLB, targets, err)
+		t.Fatalf(
+			"expected network load balancer path: calledLB=%v calledNLB=%v targets=%v err=%v",
+			calledLB,
+			calledNLB,
+			targets,
+			err,
+		)
 	}
 }
 
@@ -96,25 +132,55 @@ func TestRegisterBackendsDelegation(t *testing.T) {
 	}()
 
 	calledLB := false
-	loadBalancerRegisterBackends = func(context.Context, common.ConfigurationProvider, api.LBRegistrarSpec, *corev1.NodeList) error {
+	loadBalancerRegisterBackends = func(
+		context.Context,
+		common.ConfigurationProvider,
+		api.LBRegistrarSpec,
+		*corev1.NodeList,
+	) error {
 		calledLB = true
 		return nil
 	}
 
 	calledNLB := false
-	networkRegisterBackends = func(context.Context, common.ConfigurationProvider, api.LBRegistrarSpec, *corev1.NodeList) error {
+	networkRegisterBackends = func(
+		context.Context,
+		common.ConfigurationProvider,
+		api.LBRegistrarSpec,
+		*corev1.NodeList,
+	) error {
 		calledNLB = true
 		return nil
 	}
 
-	if err := RegisterBackends(context.Background(), nil, api.LBRegistrarSpec{LoadBalancerId: "ocid1.loadbalancer"}, &corev1.NodeList{}); err != nil || !calledLB || calledNLB {
-		t.Fatalf("expected LB backend registration path, err=%v calledLB=%v calledNLB=%v", err, calledLB, calledNLB)
+	if err := RegisterBackends(
+		context.Background(),
+		nil,
+		api.LBRegistrarSpec{LoadBalancerId: "ocid1.loadbalancer"},
+		&corev1.NodeList{},
+	); err != nil || !calledLB || calledNLB {
+		t.Fatalf(
+			"expected LB backend registration path, err=%v calledLB=%v calledNLB=%v",
+			err,
+			calledLB,
+			calledNLB,
+		)
 	}
 
 	calledLB = false
 	calledNLB = false
-	if err := RegisterBackends(context.Background(), nil, api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1"}, &corev1.NodeList{}); err != nil || !calledNLB || calledLB {
-		t.Fatalf("expected NLB backend registration path, err=%v calledLB=%v calledNLB=%v", err, calledLB, calledNLB)
+	if err := RegisterBackends(
+		context.Background(),
+		nil,
+		api.LBRegistrarSpec{LoadBalancerId: "ocid1.networkloadbalancer.oc1"},
+		&corev1.NodeList{},
+	); err != nil || !calledNLB || calledLB {
+		t.Fatalf(
+			"expected NLB backend registration path, err=%v calledLB=%v calledNLB=%v",
+			err,
+			calledLB,
+			calledNLB,
+		)
 	}
 }
 

--- a/internal/controller/endpoints_handler.go
+++ b/internal/controller/endpoints_handler.go
@@ -44,27 +44,43 @@ type EndpointsHandler struct {
 }
 
 // Create handles endpoints creation events.
-func (eh *EndpointsHandler) Create(ctx context.Context, evt event.TypedCreateEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (eh *EndpointsHandler) Create(
+	ctx context.Context,
+	evt event.TypedCreateEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	logger := log.FromContext(ctx, "endpoints", evt.Object.GetName(), "namespace", evt.Object.GetNamespace())
 	logger.V(1).Info("endpoints creation")
 	eh.handleEndpointsChange(ctx, evt.Object)
 }
 
 // Update handles endpoints update events.
-func (eh *EndpointsHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (eh *EndpointsHandler) Update(
+	ctx context.Context,
+	evt event.TypedUpdateEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	logger := log.FromContext(ctx, "endpoints", evt.ObjectNew.GetName(), "namespace", evt.ObjectNew.GetNamespace())
 	logger.V(1).Info("endpoints update")
 	eh.handleEndpointsChange(ctx, evt.ObjectNew)
 }
 
 // Delete handles endpoints deletion events.
-func (eh *EndpointsHandler) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (eh *EndpointsHandler) Delete(
+	ctx context.Context,
+	evt event.TypedDeleteEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	logger := log.FromContext(ctx, "endpoints", evt.Object.GetName(), "namespace", evt.Object.GetNamespace())
 	logger.V(1).Info("endpoints deletion")
 	eh.handleEndpointsChange(ctx, evt.Object)
 }
 
-func (eh *EndpointsHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[client.Object], _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (eh *EndpointsHandler) Generic(
+	ctx context.Context,
+	evt event.TypedGenericEvent[client.Object],
+	_ workqueue.TypedRateLimitingInterface[reconcile.Request],
+) {
 	// Do nothing
 }
 
@@ -108,12 +124,24 @@ func (eh *EndpointsHandler) handleEndpointsChange(ctx context.Context, obj clien
 			if lb.Status.Phase != api.PhasePending && lb.Status.Phase != api.PhaseNew {
 				lb.Status.Phase = api.PhasePending
 				if err := eh.Status().Update(ctx, &lb); err != nil {
-					logger.Error(err, "failed to update LBRegistrar status", "registrar", lb.Name)
+					logger.Error(
+						err,
+						"failed to update LBRegistrar status",
+						"registrar",
+						lb.Name,
+					)
 					continue
 				}
-				eh.Recorder.Event(&lb, corev1.EventTypeNormal, "EndpointsChanged",
-					fmt.Sprintf("Service %s/%s endpoints changed, triggering reconciliation",
-						obj.GetNamespace(), obj.GetName()))
+				eh.Recorder.Event(
+					&lb,
+					corev1.EventTypeNormal,
+					"EndpointsChanged",
+					fmt.Sprintf(
+						"Service %s/%s endpoints changed, triggering reconciliation",
+						obj.GetNamespace(),
+						obj.GetName(),
+					),
+				)
 				affectedCount++
 			}
 		}

--- a/internal/controller/endpoints_handler_test.go
+++ b/internal/controller/endpoints_handler_test.go
@@ -252,7 +252,9 @@ func TestEndpointsHandlerEvents(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ep := &corev1.Endpoints{ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"}} //nolint:staticcheck // keep Endpoints for backward-compat coverage
+	ep := &corev1.Endpoints{ //nolint:staticcheck // keep Endpoints for backward-compat coverage
+		ObjectMeta: metav1.ObjectMeta{Name: "svc", Namespace: "default"},
+	}
 
 	handler.Create(ctx, event.TypedCreateEvent[client.Object]{Object: ep}, nil)
 	handler.Update(ctx, event.TypedUpdateEvent[client.Object]{ObjectOld: ep, ObjectNew: ep}, nil)

--- a/internal/controller/lbregistrar_controller_reconcile_test.go
+++ b/internal/controller/lbregistrar_controller_reconcile_test.go
@@ -72,7 +72,12 @@ func TestLBRegistrarReconciler_Reconcile(t *testing.T) {
 			WithStatusSubresource(&api.LBRegistrar{}).Build()
 		r := &LBRegistrarReconciler{Client: c, Scheme: scheme, Recorder: record.NewFakeRecorder(10)}
 
-		_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"}})
+		_, err := r.Reconcile(
+			context.Background(),
+			ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+			},
+		)
 		if err != nil {
 			t.Fatalf("Reconcile returned error: %v", err)
 		}
@@ -149,7 +154,12 @@ func TestLBRegistrarReconciler_Reconcile(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 		r := &LBRegistrarReconciler{Client: c, Scheme: scheme, Recorder: recorder}
 
-		result, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"}})
+		result, err := r.Reconcile(
+			context.Background(),
+			ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test", Namespace: "default"},
+			},
+		)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/controller/lbregistrar_controller_test.go
+++ b/internal/controller/lbregistrar_controller_test.go
@@ -66,8 +66,11 @@ var _ = Describe("LBRegistrar Controller", func() {
 							Tenancy:     "ten",
 							Region:      "reg",
 							PrivateKey: nodesv1alpha1.PrivateKeySpec{
-								Namespace:    "default",
-								SecretKeyRef: corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "test-secret"}, Key: "key"},
+								Namespace: "default",
+								SecretKeyRef: corev1.SecretKeySelector{
+									LocalObjectReference: corev1.LocalObjectReference{Name: "test-secret"},
+									Key:                  "key",
+								},
 							},
 						},
 					},

--- a/internal/controller/lbregistrar_controller_unit_test.go
+++ b/internal/controller/lbregistrar_controller_unit_test.go
@@ -41,11 +41,19 @@ func TestRegisterAllNodes(t *testing.T) {
 		Spec: api.LBRegistrarSpec{
 			LoadBalancerId: "lb",
 			BackendSetName: "backend",
-			ApiKey:         api.ApiKeySpec{User: "user", Fingerprint: "fp", Tenancy: "ten", Region: "reg", PrivateKey: api.PrivateKeySpec{}},
+			ApiKey: api.ApiKeySpec{
+				User:        "user",
+				Fingerprint: "fp",
+				Tenancy:     "ten",
+				Region:      "reg",
+				PrivateKey:  api.PrivateKeySpec{},
+			},
 		},
 	}
 
-	builder := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(append(nodes, registrar)...)
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithRuntimeObjects(append(nodes, registrar)...)
 	clnt := builder.Build()
 
 	originalProvider := getConfigurationProviderFunc
@@ -55,7 +63,11 @@ func TestRegisterAllNodes(t *testing.T) {
 		registerBackendsFunc = originalRegister
 	}()
 
-	getConfigurationProviderFunc = func(context.Context, client.Client, *api.LBRegistrar) (common.ConfigurationProvider, error) {
+	getConfigurationProviderFunc = func(
+		context.Context,
+		client.Client,
+		*api.LBRegistrar,
+	) (common.ConfigurationProvider, error) {
 		return nil, nil
 	}
 
@@ -144,11 +156,18 @@ func TestRegisterMultipleServices(t *testing.T) {
 					BackendSetName:    "override",
 				},
 			},
-			ApiKey: api.ApiKeySpec{User: "user", Fingerprint: "fp", Tenancy: "ten", Region: "reg", PrivateKey: api.PrivateKeySpec{}},
+			ApiKey: api.ApiKeySpec{
+				User:        "user",
+				Fingerprint: "fp",
+				Tenancy:     "ten",
+				Region:      "reg",
+				PrivateKey:  api.PrivateKeySpec{},
+			},
 		},
 	}
 
-	builder := fake.NewClientBuilder().WithScheme(scheme).
+	builder := fake.NewClientBuilder().
+		WithScheme(scheme).
 		WithRuntimeObjects(node1, node2, svc1, svc2, endpoints, pod)
 	clnt := builder.Build()
 
@@ -161,7 +180,12 @@ func TestRegisterMultipleServices(t *testing.T) {
 		weight  int
 	}, 0)
 
-	registerBackendsFunc = func(_ context.Context, _ common.ConfigurationProvider, spec api.LBRegistrarSpec, nodes *corev1.NodeList) error {
+	registerBackendsFunc = func(
+		_ context.Context,
+		_ common.ConfigurationProvider,
+		spec api.LBRegistrarSpec,
+		nodes *corev1.NodeList,
+	) error {
 		calls = append(calls, struct {
 			backend string
 			nodes   int

--- a/internal/controller/service_filtering_edge_test.go
+++ b/internal/controller/service_filtering_edge_test.go
@@ -63,7 +63,8 @@ var _ = Describe("Service-based node filtering edge cases", func() {
 				},
 			}
 
-			objects := []runtime.Object{endpoints}
+			objects := make([]runtime.Object, 0, 1+len(nodes)+len(pods))
+			objects = append(objects, endpoints)
 			for i := range nodes {
 				objects = append(objects, &nodes[i])
 			}
@@ -105,7 +106,8 @@ var _ = Describe("Service-based node filtering edge cases", func() {
 				},
 			}
 
-			objects := []runtime.Object{endpoints}
+			objects := make([]runtime.Object, 0, 1+len(nodes)+len(pods))
+			objects = append(objects, endpoints)
 			for i := range nodes {
 				objects = append(objects, &nodes[i])
 			}

--- a/internal/controller/service_filtering_test.go
+++ b/internal/controller/service_filtering_test.go
@@ -118,7 +118,8 @@ var _ = Describe("Service-based Node Filtering", func() {
 			},
 		}
 
-		objects = []runtime.Object{endpoints}
+		objects = make([]runtime.Object, 0, 1+len(nodes)+len(pods))
+		objects = append(objects, endpoints)
 		for i := range nodes {
 			objects = append(objects, &nodes[i])
 		}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 		BinaryAssetsDirectory: absBinDir,
 	}
 	apiserver := testEnv.ControlPlane.GetAPIServer()
-	apiserver.SecureServing.Address = "127.0.0.1"
+	apiserver.Address = "127.0.0.1"
 	apiserver.Configure().Set("advertise-address", "127.0.0.1")
 
 	var err error

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -141,6 +141,6 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, err
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }


### PR DESCRIPTION
Summary
- Adjust NLB backend set access to use embedded response fields and align related tests/formatting.
- Update lint configuration for golangci-lint v2 and refresh Makefile tool install path.
- Document coverage threshold in AGENTS guidelines.

Testing
- `make test` (pass; packages: 7 ok, 1 no test files, 1 coverage-only)
- `make lint` (pass)
- `go tool cover -func=cover.out` (pass; via `make cover`)

Coverage
- `make cover` (pass)
- Lines: 80.2% (threshold 80%; met)
